### PR TITLE
feat: Add support for plural ICU MessageFormat in ARB translations

### DIFF
--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -16,30 +16,110 @@ class Translator {
       throw Exception("❌ Error: Cannot translate empty text.");
     }
 
-    // Check if key has `skipIgnorePhrases` enabled
+    // ✅ **Check if `skipIgnorePhrases` is enabled for this key**
     if (keyConfig.containsKey(key) &&
         keyConfig[key]['skipIgnorePhrases'] == true) {
       return _translate(text, fromLang, toLang);
     }
 
-    // Determine ignore phrases for this key
-    List<String> ignorePhrases = globalIgnorePhrases;
-    if (keyConfig.containsKey(key) &&
-        keyConfig[key].containsKey('ignore_phrases')) {
-      ignorePhrases = List<String>.from(keyConfig[key]['ignore_phrases']);
+    // ✅ **Handle ICU Plural Messages Separately**
+    if (_isICUPluralMessage(text)) {
+      return _translateICUPluralMessage(key, text, fromLang, toLang);
     }
 
-    // ✅ If the entire text matches an ignored phrase, return as-is.
-    if (ignorePhrases.contains(text)) {
-      return text;
-    }
+    if (_shouldSkipTranslation(text)) return text;
 
-    // Placeholder replacement logic for partial matches
+    // ✅ **Apply Ignore Phrases BEFORE translation**
     Map<String, String> placeholderMap = {};
+    String modifiedText =
+        _applyIgnorePhrasesBeforeTranslation(text, placeholderMap);
+
+    // ✅ **Translate the modified text**
+    String translatedText = await _translate(modifiedText, fromLang, toLang);
+
+    // ✅ **Restore ignored phrases AFTER translation**
+    translatedText =
+        _restoreIgnoredPhrasesAfterTranslation(translatedText, placeholderMap);
+
+    return translatedText;
+  }
+
+  /// ✅ **Detects ICU Plural Messages**
+  bool _isICUPluralMessage(String text) {
+    return text.contains(RegExp(r'{\w+, plural,'));
+  }
+
+  /// ✅ **Processes and Translates ICU Plural Messages Correctly**
+  Future<String> _translateICUPluralMessage(
+      String key, String text, String fromLang, String toLang) async {
+    final regex = RegExp(r'\{(\w+), plural, (.+)\}$', dotAll: true);
+    final match = regex.firstMatch(text);
+
+    if (match == null) {
+      return text; // Return original if no plural pattern detected
+    }
+    final variable =
+        match.group(1)!; // Extract placeholder variable (e.g., "count")
+    String pluralRules =
+        match.group(2)!; // Extract all rules: zero{}, one{}, other{}
+
+    final translatedRules = <String, String>{};
+
+    // ✅ **Regex to Capture All Plural Rules Properly**
+    final ruleRegex = RegExp(r'(\w+)\{((?:[^\{\}]|\{[^\{\}]*\})*)\}');
+
+    for (final ruleMatch in ruleRegex.allMatches(pluralRules)) {
+      final ruleType = ruleMatch.group(1)!; // e.g., "zero", "one", "other"
+      String ruleText =
+          ruleMatch.group(2)!; // e.g., "You have {count} new messages"
+
+      // ✅ **Apply ignore phrases before translation**
+      Map<String, String> placeholderMap = {};
+      ruleText = _applyIgnorePhrasesBeforeTranslation(ruleText, placeholderMap);
+      ruleText = ruleText.replaceAll('{count}', '[COUNT_PLACEHOLDER]');
+
+      // ✅ **Translate the modified text**
+      String translatedRuleText = await _translate(ruleText, fromLang, toLang);
+
+      // ✅ **Restore ignored phrases AFTER translation**
+      translatedRuleText = _restoreIgnoredPhrasesAfterTranslation(
+          translatedRuleText, placeholderMap);
+      translatedRuleText =
+          translatedRuleText.replaceAll('[COUNT_PLACEHOLDER]', '{count}');
+
+      translatedRules[ruleType] = translatedRuleText;
+    }
+
+    // ✅ **Rebuild the ICU plural message format correctly**
+    final translatedPluralText =
+        '{$variable, plural, ${translatedRules.entries.map((e) => '${e.key}{${e.value}}').join(' ')}}';
+
+    return translatedPluralText;
+  }
+
+  /// ✅ **Check whether the text should not be translated at all**
+  bool _shouldSkipTranslation(
+    String text,
+  ) =>
+      (keyConfig.containsKey(text)
+          ? (keyConfig[text]['skipIgnorePhrases'] != true)
+          : true) &&
+      globalIgnorePhrases.contains(text);
+
+  /// ✅ **Applies Ignore Phrases Before Translation**
+  /// - Replaces ignored words with placeholders before translation.
+  /// - Stores original words in `placeholderMap` for later restoration.
+  String _applyIgnorePhrasesBeforeTranslation(
+      String text, Map<String, String> placeholderMap) {
+    if (keyConfig.containsKey(text) &&
+        keyConfig[text]['skipIgnorePhrases'] == true) {
+      return text; // Skip ignore checks if configured
+    }
+
     String modifiedText = text;
 
-    for (int i = 0; i < ignorePhrases.length; i++) {
-      String phrase = ignorePhrases[i];
+    for (int i = 0; i < globalIgnorePhrases.length; i++) {
+      String phrase = globalIgnorePhrases[i];
 
       if (modifiedText.contains(phrase)) {
         String placeholder = "[IGNORE_$i]";
@@ -48,17 +128,21 @@ class Translator {
       }
     }
 
-    // Translate only the modifiable parts
-    String translatedText = await _translate(modifiedText, fromLang, toLang);
-
-    // Restore ignored phrases
-    placeholderMap.forEach((placeholder, originalText) {
-      translatedText = translatedText.replaceAll(placeholder, originalText);
-    });
-
-    return translatedText;
+    return modifiedText;
   }
 
+  /// ✅ **Restores Ignored Phrases After Translation**
+  /// - Restores original words using `placeholderMap` after translation.
+  String _restoreIgnoredPhrasesAfterTranslation(
+      String text, Map<String, String> placeholderMap) {
+    placeholderMap.forEach((placeholder, originalText) {
+      text = text.replaceAll(placeholder, originalText);
+    });
+
+    return text;
+  }
+
+  /// ✅ **Calls Google Translate API**
   Future<String> _translate(String text, String fromLang, String toLang) async {
     final url = Uri.parse(
         'https://translation.googleapis.com/language/translate/v2?key=$apiKey');


### PR DESCRIPTION
- Detects and translates ICU MessageFormat pluralization rules in `.arb` files.
- Ensures placeholders like `{count}` remain unchanged.
- Translates only inner message texts while keeping the ICU structure intact.
- Enhances CLI workflow to handle `zero{}` `one{}` `other{}` correctly.
- Improves localization accuracy for dynamic text formatting.

🎯 Enables automatic translation for plural messages in Flutter ARB files.