### PR TITLE
refactor: Translator class for improved readability and reusability

### DIFF
--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -16,176 +16,104 @@ class Translator {
       throw Exception("❌ Error: Cannot translate empty text.");
     }
 
-    // ✅ **Handle ICU Plural Messages Separately**
-    if (_isICUPluralMessage(text)) {
-      return _translateICUPluralMessage(key, text, fromLang, toLang);
+    // ✅ Handle ICU Messages
+    if (_isICUPlural(text)) {
+      return _processICUMessage(key, text, fromLang, toLang, "plural");
+    }
+    if (_isICUSelect(text)) {
+      return _processICUMessage(key, text, fromLang, toLang, "select");
     }
 
-    // ✅ **Handle ICU Plural Select Separately**
-    if (_isICUSelectMessage(text)) {
-      return _translateICUSelectMessage(key, text, fromLang, toLang);
-    }
+    if (_shouldSkipTranslation(key, text)) return text;
 
-    if (_shouldSkipTranslation(text)) return text;
-
-    // ✅ **Apply Ignore Phrases BEFORE translation**
+    // ✅ Apply Ignore Phrases BEFORE translation
     Map<String, String> placeholderMap = {};
     String modifiedText =
-        _applyIgnorePhrasesBeforeTranslation(key, text, placeholderMap);
+        _replaceIgnorePhrasesWithPlaceholders(key, text, placeholderMap);
 
-    // ✅ **Translate the modified text**
+    // ✅ Translate the modified text
     String translatedText = await _translate(modifiedText, fromLang, toLang);
 
-    // ✅ **Restore ignored phrases AFTER translation**
-    translatedText =
-        _restoreIgnoredPhrasesAfterTranslation(translatedText, placeholderMap);
+    // ✅ Restore ignored phrases AFTER translation
+    translatedText = _restorePlaceholders(translatedText, placeholderMap);
 
     return translatedText;
   }
 
-  /// ✅ **Detects ICU Gender-Based Select Messages**
-  bool _isICUSelectMessage(String text) {
+  /// ✅ Detects ICU Select Messages
+  bool _isICUSelect(String text) {
     return text.contains(RegExp(r'{\w+, select,'));
   }
 
-  /// ✅ **Processes and Translates ICU Select Messages Correctly**
-  Future<String> _translateICUSelectMessage(
-      String key, String text, String fromLang, String toLang) async {
-    final regex = RegExp(r'\{(\w+), select, (.+)\}$', dotAll: true);
-    final match = regex.firstMatch(text);
-
-    if (match == null) {
-      return text; // Return original if no select pattern detected
-    }
-
-    final variable =
-        match.group(1)!; // Extract placeholder variable (e.g., "sex")
-    String selectRules =
-        match.group(2)!; // Extract all rules: male{}, female{}, other{}
-
-    final translatedRules = <String, String>{};
-
-    // ✅ **Regex to Capture All Select Rules Properly**
-    final ruleRegex = RegExp(r'(\w+)\{((?:[^\{\}]|\{[^\{\}]*\})*)\}');
-
-    for (final ruleMatch in ruleRegex.allMatches(selectRules)) {
-      final ruleType = ruleMatch.group(1)!; // e.g., "male", "female", "other"
-      String ruleText = ruleMatch.group(2)!; // e.g., "His birthday"
-
-      // ✅ **Apply ignore phrases before translation**
-      Map<String, String> placeholderMap = {};
-      ruleText =
-          _applyIgnorePhrasesBeforeTranslation(key, ruleText, placeholderMap);
-
-      // ✅ **Translate the modified text**
-      String translatedRuleText = await _translate(ruleText, fromLang, toLang);
-
-      // ✅ **Restore ignored phrases AFTER translation**
-      translatedRuleText = _restoreIgnoredPhrasesAfterTranslation(
-          translatedRuleText, placeholderMap);
-
-      translatedRules[ruleType] = translatedRuleText;
-    }
-
-    // ✅ **Rebuild the ICU select message format correctly**
-    final translatedSelectText =
-        '{$variable, select, ${translatedRules.entries.map((e) => '${e.key}{${e.value}}').join(' ')}}';
-
-    return translatedSelectText;
-  }
-
-  /// ✅ **Detects ICU Plural Messages**
-  bool _isICUPluralMessage(String text) {
+  /// ✅ Detects ICU Plural Messages
+  bool _isICUPlural(String text) {
     return text.contains(RegExp(r'{\w+, plural,'));
   }
 
-  /// ✅ **Processes and Translates ICU Plural Messages Correctly**
-  Future<String> _translateICUPluralMessage(
-      String key, String text, String fromLang, String toLang) async {
-    final regex = RegExp(r'\{(\w+), plural, (.+)\}$', dotAll: true);
+  /// ✅ Processes and Translates ICU Messages (Plural or Select)
+  Future<String> _processICUMessage(String key, String text, String fromLang,
+      String toLang, String type) async {
+    final regex = RegExp(r'\{(\w+), ' + type + r', (.+)\}$', dotAll: true);
     final match = regex.firstMatch(text);
 
     if (match == null) {
-      return text; // Return original if no plural pattern detected
+      return text;
     }
-    final variable =
-        match.group(1)!; // Extract placeholder variable (e.g., "count")
-    String pluralRules =
-        match.group(2)!; // Extract all rules: zero{}, one{}, other{}
+
+    final variable = match.group(1)!;
+    String rules = match.group(2)!;
 
     final translatedRules = <String, String>{};
-
-    // ✅ **Regex to Capture All Plural Rules Properly**
     final ruleRegex = RegExp(r'(\w+)\{((?:[^\{\}]|\{[^\{\}]*\})*)\}');
 
-    for (final ruleMatch in ruleRegex.allMatches(pluralRules)) {
-      final ruleType = ruleMatch.group(1)!; // e.g., "zero", "one", "other"
-      String ruleText =
-          ruleMatch.group(2)!; // e.g., "You have {count} new messages"
+    for (final ruleMatch in ruleRegex.allMatches(rules)) {
+      final ruleType = ruleMatch.group(1)!;
+      String ruleText = ruleMatch.group(2)!;
 
-      // ✅ **Apply ignore phrases before translation**
-      Map<String, String> placeholderMap = {};
-      ruleText =
-          _applyIgnorePhrasesBeforeTranslation(key, ruleText, placeholderMap);
-      ruleText = ruleText.replaceAll('{count}', '[COUNT_PLACEHOLDER]');
-
-      // ✅ **Translate the modified text**
-      String translatedRuleText = await _translate(ruleText, fromLang, toLang);
-
-      // ✅ **Restore ignored phrases AFTER translation**
-      translatedRuleText = _restoreIgnoredPhrasesAfterTranslation(
-          translatedRuleText, placeholderMap);
-      translatedRuleText =
-          translatedRuleText.replaceAll('[COUNT_PLACEHOLDER]', '{count}');
-
-      translatedRules[ruleType] = translatedRuleText;
+      translatedRules[ruleType] =
+          await _translateTextSegment(ruleText, fromLang, toLang, key);
     }
 
-    // ✅ **Rebuild the ICU plural message format correctly**
-    final translatedPluralText =
-        '{$variable, plural, ${translatedRules.entries.map((e) => '${e.key}{${e.value}}').join(' ')}}';
-
-    return translatedPluralText;
+    return '{$variable, $type, ${translatedRules.entries.map((e) => '${e.key}{${e.value}}').join(' ')}}';
   }
 
-  /// ✅ **Check whether the text should not be translated at all**
-  bool _shouldSkipTranslation(
-    String text,
-  ) =>
-      (keyConfig.containsKey(text)
-          ? (keyConfig[text]['skipIgnorePhrases'] != true)
-          : true) &&
-      globalIgnorePhrases.contains(text);
+  /// ✅ Translates a text segment while handling placeholders
+  Future<String> _translateTextSegment(
+      String text, String fromLang, String toLang, String key) async {
+    Map<String, String> placeholderMap = {};
+    String modifiedText =
+        _replaceIgnorePhrasesWithPlaceholders(key, text, placeholderMap);
 
-  /// ✅ **Applies Ignore Phrases Before Translation**
-  /// - Uses per-key ignore phrases if `skipIgnorePhrases == true`.
-  /// - Otherwise, merges global and per-key ignore phrases.
-  /// - Replaces ignored words with placeholders.
-  String _applyIgnorePhrasesBeforeTranslation(
-    String key,
-    String text,
-    Map<String, String> placeholderMap,
-  ) {
-    // Retrieve per-key ignore phrases
+    String translatedText = await _translate(modifiedText, fromLang, toLang);
+    return _restorePlaceholders(translatedText, placeholderMap);
+  }
+
+  /// ✅ Determines if translation should be skipped
+  bool _shouldSkipTranslation(String key, String text) {
+    return _getIgnorePhrasesForKey(key).contains(text);
+  }
+
+  /// ✅ Retrieves ignore phrases for a given key (Merges global + per-key)
+  List<String> _getIgnorePhrasesForKey(String key) {
     List<String> perKeyIgnorePhrases =
         keyConfig.containsKey(key) && keyConfig[key]['ignore_phrases'] is List
             ? List<String>.from(keyConfig[key]['ignore_phrases'])
             : [];
 
-    // Determine if we should skip global ignore phrases
-    bool skipGlobalIgnore = keyConfig.containsKey(key) &&
-        keyConfig[key]['skipIgnorePhrases'] == true;
-
-    // If skipIgnorePhrases is true, only use per-key ignore phrases.
-    // Otherwise, merge global and per-key ignore phrases.
-    List<String> combinedIgnorePhrases = skipGlobalIgnore
+    return keyConfig.containsKey(key) &&
+            keyConfig[key]['skipIgnorePhrases'] == true
         ? perKeyIgnorePhrases
         : [...globalIgnorePhrases, ...perKeyIgnorePhrases];
+  }
 
+  /// ✅ Replaces ignore phrases with placeholders before translation
+  String _replaceIgnorePhrasesWithPlaceholders(
+      String key, String text, Map<String, String> placeholderMap) {
+    List<String> ignorePhrases = _getIgnorePhrasesForKey(key);
     String modifiedText = text;
 
-    for (int i = 0; i < combinedIgnorePhrases.length; i++) {
-      String phrase = combinedIgnorePhrases[i];
+    for (int i = 0; i < ignorePhrases.length; i++) {
+      String phrase = ignorePhrases[i];
 
       if (modifiedText.contains(phrase)) {
         final placeholder = "[IGNORE_$i]";
@@ -193,14 +121,11 @@ class Translator {
         modifiedText = modifiedText.replaceAll(phrase, placeholder);
       }
     }
-
     return modifiedText;
   }
 
-  /// ✅ **Restores Ignored Phrases After Translation**
-  /// - Restores original words using `placeholderMap` after translation.
-  String _restoreIgnoredPhrasesAfterTranslation(
-      String text, Map<String, String> placeholderMap) {
+  /// ✅ Restores placeholders after translation
+  String _restorePlaceholders(String text, Map<String, String> placeholderMap) {
     placeholderMap.forEach((placeholder, originalText) {
       text = text.replaceAll(placeholder, originalText);
     });
@@ -208,7 +133,7 @@ class Translator {
     return text;
   }
 
-  /// ✅ **Calls Google Translate API**
+  /// ✅ Calls Google Translate API
   Future<String> _translate(String text, String fromLang, String toLang) async {
     final url = Uri.parse(
         'https://translation.googleapis.com/language/translate/v2?key=$apiKey');


### PR DESCRIPTION
 - Extract `_getIgnorePhrasesForKey()` to dynamically handle ignore phrases
- Merge `_translateICUPluralMessage` and `_translateICUSelectMessage` into `_processICUMessage()`
- Simplify `_shouldSkipTranslation()` logic using `_getIgnorePhrasesForKey()`
- Extract `_translateTextSegment()` to remove duplicate translation logic
- Rename functions for clarity (`_applyIgnorePhrasesBeforeTranslation` → `_replaceIgnorePhrasesWithPlaceholders`)
- Improve regex handling for ICU messages 🎯 Makes the translation logic cleaner, reusable, and more maintainable