### PR TITLE
feat: Add translation character count estimator before job execution

### DIFF
--- a/lib/flutter_auto_localizations.dart
+++ b/lib/flutter_auto_localizations.dart
@@ -1,3 +1,4 @@
 export "./src/config_parser.dart";
 export './src/file_manager.dart';
+export './src/translation_estimator.dart';
 export './src/translator.dart';

--- a/lib/src/translation_estimator.dart
+++ b/lib/src/translation_estimator.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:io';
+
+class TranslationEstimator {
+  static const int freeTierLimit = 500000; // Free for first 500K characters (per month)
+  static const double pricePerMillion = 20.00; // $20 per million characters
+  static const String pricingUrl = "https://cloud.google.com/translate/pricing#basic-pricing"; // Google Pricing Page
+
+  static void estimateTranslationCost(String arbFilePath, List<String> targetLanguages) {
+    final file = File(arbFilePath);
+    if (!file.existsSync()) {
+      print("❌ Error: ARB file not found: $arbFilePath");
+      return;
+    }
+
+    final Map<String, dynamic> arbData = jsonDecode(file.readAsStringSync());
+    int totalCharacters = 0;
+
+    // Count translatable characters (ignore keys and metadata)
+    arbData.forEach((key, value) {
+      if (!key.startsWith("@") && value is String) {
+        totalCharacters += value.length;
+      }
+    });
+
+    // Calculate estimated total translated characters
+    int estimatedTranslatedCharacters = totalCharacters * targetLanguages.length;
+
+    // ✅ Calculate estimated cost for ALL characters (no free tier subtraction)
+    double estimatedCost = (estimatedTranslatedCharacters / 1_000_000) * pricePerMillion;
+
+    // Display output
+    print("\n📊 Translation Character Estimate:");
+    print("-----------------------------------");
+    print("🌍 Source ARB File: $arbFilePath");
+    print("🔤 Estimated Total Characters: ${_formatNumber(totalCharacters)}");
+    print("📌 Target Languages: ${targetLanguages.join(', ')}");
+    print("🔣 Total Estimated Translated Characters: ${_formatNumber(estimatedTranslatedCharacters)}");
+
+    print("💰 Estimated Total Cost: \$${estimatedCost.toStringAsFixed(2)}");
+
+    print("ℹ️ Free Tier: First ${_formatNumber(freeTierLimit)} characters per month are free, if applicable.");
+    print("🔗 More details on pricing: $pricingUrl");
+    print("🚧 Note: This is an estimate. Actual cost depends on API usage.");
+    print("------------------------------------------------\n");
+  }
+
+  /// ✅ Formats numbers with commas for better readability
+  static String _formatNumber(int number) {
+    return number.toString().replaceAllMapped(RegExp(r'\B(?=(\d{3})+(?!\d))'), (match) => ",");
+  }
+}


### PR DESCRIPTION
- Counts total characters in ARB file (excluding keys & placeholders)
- Multiplies by the number of target languages
- Displays an estimate possible API costs 
🎯 Helps users predict translation expenses before starting