### PR TITLE
fix: Increase Dart SDK compatibility for older projects

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "_macros",
-      "rootUri": "file:///Users/dewminaudayashan/development/flutter/bin/cache/dart-sdk/pkg/_macros",
+      "rootUri": "file:///Users/dewminaudayashan/fvm/versions/stable/bin/cache/dart-sdk/pkg/_macros",
       "packageUri": "lib/",
       "languageVersion": "3.4"
     },
@@ -431,13 +431,13 @@
       "name": "flutter_auto_localizations",
       "rootUri": "../",
       "packageUri": "lib/",
-      "languageVersion": "3.6"
+      "languageVersion": "2.17"
     }
   ],
-  "generated": "2025-02-09T07:27:27.857797Z",
+  "generated": "2025-02-10T15:46:33.767609Z",
   "generator": "pub",
-  "generatorVersion": "3.6.1",
-  "flutterRoot": "file:///Users/dewminaudayashan/development/flutter",
-  "flutterVersion": "3.27.3",
+  "generatorVersion": "3.6.2",
+  "flutterRoot": "file:///Users/dewminaudayashan/fvm/versions/stable",
+  "flutterVersion": "3.27.4",
   "pubCache": "file:///Users/dewminaudayashan/.pub-cache"
 }

--- a/lib/src/translation_estimator.dart
+++ b/lib/src/translation_estimator.dart
@@ -2,11 +2,16 @@ import 'dart:convert';
 import 'dart:io';
 
 class TranslationEstimator {
-  static const int freeTierLimit = 500000; // Free for first 500K characters (per month)
+  static const int freeTierLimit =
+      500000; // Free for first 500K characters (per month)
   static const double pricePerMillion = 20.00; // $20 per million characters
-  static const String pricingUrl = "https://cloud.google.com/translate/pricing#basic-pricing"; // Google Pricing Page
+  static const String pricingUrl =
+      "https://cloud.google.com/translate/pricing#basic-pricing"; // Google Pricing Page
 
-  static void estimateTranslationCost(String arbFilePath, List<String> targetLanguages) {
+  static void estimateTranslationCost(
+    String arbFilePath,
+    List<String> targetLanguages,
+  ) {
     final file = File(arbFilePath);
     if (!file.existsSync()) {
       print("❌ Error: ARB file not found: $arbFilePath");
@@ -24,10 +29,12 @@ class TranslationEstimator {
     });
 
     // Calculate estimated total translated characters
-    final estimatedTranslatedCharacters = totalCharacters * targetLanguages.length;
+    final estimatedTranslatedCharacters =
+        totalCharacters * targetLanguages.length;
 
     // ✅ Calculate estimated cost for ALL characters (no free tier subtraction)
-    final estimatedCost = (estimatedTranslatedCharacters / 1_000_000) * pricePerMillion;
+    final estimatedCost =
+        (estimatedTranslatedCharacters / 1000000) * pricePerMillion;
 
     // Display output
     print("\n📊 Translation Character Estimate:");
@@ -35,11 +42,13 @@ class TranslationEstimator {
     print("🌍 Source ARB File: $arbFilePath");
     print("🔤 Estimated Total Characters: ${formatNumber(totalCharacters)}");
     print("📌 Target Languages: ${targetLanguages.join(', ')}");
-    print("🔣 Total Estimated Translated Characters: ${formatNumber(estimatedTranslatedCharacters)}");
+    print(
+        "🔣 Total Estimated Translated Characters: ${formatNumber(estimatedTranslatedCharacters)}");
 
     print("💰 Estimated Total Cost: \$${estimatedCost.toStringAsFixed(2)}");
 
-    print("ℹ️ Free Tier: First ${formatNumber(freeTierLimit)} characters per month are free, if applicable.");
+    print(
+        "ℹ️ Free Tier: First ${formatNumber(freeTierLimit)} characters per month are free, if applicable.");
     print("🔗 More details on pricing: $pricingUrl");
     print("🚧 Note: This is an estimate. Actual cost depends on API usage.");
     print("------------------------------------------------\n");
@@ -47,6 +56,8 @@ class TranslationEstimator {
 
   /// ✅ Formats numbers with commas for better readability
   static String formatNumber(int number) {
-    return number.toString().replaceAllMapped(RegExp(r'\B(?=(\d{3})+(?!\d))'), (match) => ",");
+    return number
+        .toString()
+        .replaceAllMapped(RegExp(r'\B(?=(\d{3})+(?!\d))'), (match) => ",");
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -567,4 +567,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.6.1 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ executables:
   flutter_auto_localizations: flutter_auto_localizations
 
 environment:
-  sdk: ^3.6.1
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   dotenv: ^4.2.0


### PR DESCRIPTION
- Updated `pubspec.yaml` to support Dart versions `>=2.17.0 <4.0.0`.
- Replaced `1_000_000` with `1000000` in `translation_estimator.dart` to ensure compatibility with older Dart versions.
- Ensured that all numeric calculations remain accurate without breaking changes. 🎯 Expands support for older Flutter and Dart projects while maintaining functionality.