### PR TITLE
fix: improve ICU plural message detection and handling

### DIFF
--- a/bin/flutter_auto_localizations.dart
+++ b/bin/flutter_auto_localizations.dart
@@ -47,8 +47,11 @@ void main() async {
       exit(0);
     }
 
-    final translator = Translator(apiKey,
-        globalIgnorePhrases: globalIgnorePhrases, keyConfig: keyConfig);
+    final translator = Translator(
+      apiKey,
+      globalIgnorePhrases: globalIgnorePhrases,
+      keyConfig: keyConfig,
+    );
 
     for (final lang in targetLanguages) {
       print("\n🌍 Translating to $lang...");
@@ -80,6 +83,7 @@ void main() async {
     }
 
     print("\n🎉 Translation completed successfully!");
+    exit(0);
   } catch (e) {
     print("❌ Error: $e");
   }


### PR DESCRIPTION
- Added support for explicit number-based plural rules (=0, =1, =5, etc.)
- Ensured correct detection of standard plural cases (zero, one, two, few, many, other)
- Preserved ICU `#` placeholders during translation