### PR TITLE
fix: Improve cache key to consider ignore phrases and config flags

### DIFF
--- a/lib/src/shared/translation_config.dart
+++ b/lib/src/shared/translation_config.dart
@@ -1,0 +1,35 @@
+class TranslationConfig {
+  static TranslationConfig? _instance;
+
+  // Private constructor
+  TranslationConfig._internal({
+    required this.keyConfig,
+    required this.globalIgnorePhrases,
+    required this.enableCache,
+  });
+
+  static void initialize({
+    required Map<String, dynamic> keyConfig,
+    required List<String> globalIgnorePhrases,
+    required bool enableCache,
+  }) {
+    _instance ??= TranslationConfig._internal(
+      keyConfig: keyConfig,
+      globalIgnorePhrases: globalIgnorePhrases,
+      enableCache: enableCache,
+    );
+  }
+
+  // Public getter to access the shared instance
+  static TranslationConfig get instance {
+    if (_instance == null) {
+      throw Exception(
+          "❌ TranslationConfig is not initialized. Call TranslationConfig.initialize() first.");
+    }
+    return _instance!;
+  }
+
+  final Map<String, dynamic> keyConfig;
+  final List<String> globalIgnorePhrases;
+  final bool enableCache;
+}

--- a/lib/src/shared/translation_utils.dart
+++ b/lib/src/shared/translation_utils.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'translation_config.dart';
+
+class TranslationUtils {
+  /// ✅ Generates a consistent cache key for translations
+  static String generateCacheKey({
+    required String fromLang,
+    required String toLang,
+    required String text,
+    required String key,
+  }) {
+    final config = TranslationConfig.instance; // Use initialized instance
+
+    final perKeyConfig = config.keyConfig[key] ?? {};
+    final List<String> ignorePhrases = _getIgnorePhrasesForKey(key);
+    final bool skipGlobalIgnore = perKeyConfig['skip-global-ignore'] ?? false;
+
+    return jsonEncode({
+      "fromLang": fromLang,
+      "toLang": toLang,
+      "text": text,
+      "ignorePhrases": ignorePhrases, // Includes both global and per-key
+      "skipGlobalIgnore": skipGlobalIgnore // Flag included in cache key
+    });
+  }
+
+  /// ✅ Retrieves ignore phrases for a given key (Merges global + per-key)
+  static List<String> _getIgnorePhrasesForKey(String key) {
+    final config = TranslationConfig.instance; // Use singleton instance
+    final perKeyIgnorePhrases = config.keyConfig.containsKey(key) &&
+            config.keyConfig[key]['key-ignore-phrases'] is List
+        ? List<String>.from(config.keyConfig[key]['key-ignore-phrases'])
+        : <String>[];
+
+    return config.keyConfig.containsKey(key) &&
+            config.keyConfig[key]['skip-global-ignore'] == true
+        ? perKeyIgnorePhrases
+        : [...config.globalIgnorePhrases, ...perKeyIgnorePhrases];
+  }
+}

--- a/lib/src/shared/utils.dart
+++ b/lib/src/shared/utils.dart
@@ -1,0 +1,2 @@
+export './translation_config.dart';
+export './translation_utils.dart';


### PR DESCRIPTION
- Enhanced cache key to account for `global-ignore-phrases`, `key-ignore-phrases`, and `skip-global-ignore`.
- Prevents outdated translations when ignore phrases or configuration settings change.
- Ensures cache integrity while maintaining performance.